### PR TITLE
Create clean space theme styling

### DIFF
--- a/Space_Styles.css
+++ b/Space_Styles.css
@@ -1,21 +1,18 @@
-/* Space_Styles.css - Futuristic space station theme */
+/* Space_Styles.css - clean space/sci-fi theme */
 
 :root {
-  --color-space-900: #090a0f;
-  --color-space-800: #0f1722;
-  --color-space-700: #1b2735;
-  --color-nebula: #9370db;
-  --color-accent: #00ced1;
-  --color-star: #f8fbff;
-  --color-panel: rgba(20, 32, 48, 0.72);
-  --color-panel-strong: rgba(40, 60, 88, 0.92);
-  --font-base: 'Courier New', 'Consolas', monospace;
-  --shadow-neon: 0 0 12px rgba(0, 206, 209, 0.5), 0 0 24px rgba(147, 112, 219, 0.25);
-  --shadow-star: 0 0 18px rgba(248, 251, 255, 0.45);
-  --border-glow: 1px solid rgba(0, 206, 209, 0.5);
-  --transition-base: 250ms ease;
-  --transition-slow: 600ms ease-in-out;
-  --radius-panel: 18px;
+  --color-space-deep: #1a202c;
+  --color-space-mid: #2d3748;
+  --color-space-light: #364155;
+  --color-accent: #00bcd4;
+  --color-text: #f5f7ff;
+  --color-muted: rgba(245, 247, 255, 0.65);
+  --panel-sheen: rgba(0, 188, 212, 0.12);
+  --panel-border: rgba(0, 188, 212, 0.35);
+  --panel-shadow: 0 0 18px rgba(0, 188, 212, 0.15);
+  --transition-base: 200ms ease;
+  --radius-base: 14px;
+  --font-mono: 'Courier New', Consolas, 'Liberation Mono', monospace;
   color-scheme: dark;
 }
 
@@ -23,103 +20,100 @@
   box-sizing: border-box;
 }
 
-html,
-body {
-  height: 100%;
+html {
+  font-size: 18px;
 }
 
 body {
   margin: 0;
-  font-family: var(--font-base);
+  font-family: var(--font-mono);
   background:
-    radial-gradient(circle at 20% 20%, rgba(147, 112, 219, 0.25), transparent 55%),
-    radial-gradient(circle at 80% 30%, rgba(0, 206, 209, 0.2), transparent 60%),
-    radial-gradient(circle at 50% 80%, rgba(147, 112, 219, 0.2), transparent 60%),
-    linear-gradient(135deg, var(--color-space-900), var(--color-space-700));
-  color: var(--color-star);
-  line-height: 1.6;
+    radial-gradient(circle at 10% 15%, rgba(255, 255, 255, 0.08), transparent 45%),
+    radial-gradient(circle at 80% 20%, rgba(0, 188, 212, 0.18), transparent 55%),
+    radial-gradient(circle at 25% 70%, rgba(255, 255, 255, 0.05), transparent 55%),
+    radial-gradient(circle at 60% 85%, rgba(0, 188, 212, 0.14), transparent 65%),
+    linear-gradient(160deg, var(--color-space-deep), var(--color-space-mid));
+  color: var(--color-text);
+  line-height: 1.65;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
-  overflow-x: hidden;
   position: relative;
-}
-
-::selection {
-  background: rgba(0, 206, 209, 0.6);
-  color: var(--color-space-900);
-}
-
-body::before,
-body::after {
-  content: "";
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  z-index: -2;
-  opacity: 0.9;
+  overflow-x: hidden;
 }
 
 body::before {
-  background-image:
-    radial-gradient(2px 2px at 20px 20px, rgba(248, 251, 255, 0.95), transparent 60%),
-    radial-gradient(1.2px 1.2px at 90px 70px, rgba(248, 251, 255, 0.8), transparent 60%),
-    radial-gradient(1.6px 1.6px at 150px 120px, rgba(0, 206, 209, 0.5), transparent 65%),
-    radial-gradient(1px 1px at 250px 200px, rgba(248, 251, 255, 0.8), transparent 60%);
-  background-size: 200px 200px;
-  animation: drift-stars 35s linear infinite;
-}
-
-body::after {
-  background-image:
-    radial-gradient(1.8px 1.8px at 40px 80px, rgba(248, 251, 255, 0.8), transparent 55%),
-    radial-gradient(1px 1px at 120px 40px, rgba(147, 112, 219, 0.5), transparent 55%),
-    radial-gradient(1.4px 1.4px at 70px 160px, rgba(0, 206, 209, 0.5), transparent 60%),
-    radial-gradient(1px 1px at 200px 150px, rgba(248, 251, 255, 0.9), transparent 55%);
-  background-size: 260px 260px;
-  animation: twinkle 12s ease-in-out infinite alternate;
-  z-index: -3;
-}
-
-@keyframes drift-stars {
-  from {
-    transform: translate3d(0, 0, 0);
-  }
-  to {
-    transform: translate3d(-200px, -400px, 0);
-  }
-}
-
-@keyframes twinkle {
-  0%,
-  100% {
-    opacity: 0.45;
-  }
-  50% {
-    opacity: 0.8;
-  }
-}
-
-main::before {
   content: "";
   position: fixed;
-  inset: -30% -40% auto -40%;
-  height: 120vh;
-  background: conic-gradient(from 45deg, rgba(147, 112, 219, 0.18), rgba(0, 0, 0, 0) 35%, rgba(0, 206, 209, 0.12), rgba(0, 0, 0, 0) 70%);
-  filter: blur(120px);
-  opacity: 0.8;
+  inset: 0;
+  background:
+    radial-gradient(1px 1px at 20px 40px, rgba(255, 255, 255, 0.5), transparent 60%),
+    radial-gradient(1.5px 1.5px at 120px 80px, rgba(0, 188, 212, 0.35), transparent 60%),
+    radial-gradient(1px 1px at 200px 160px, rgba(255, 255, 255, 0.45), transparent 60%),
+    radial-gradient(2px 2px at 340px 120px, rgba(255, 255, 255, 0.35), transparent 65%),
+    radial-gradient(1px 1px at 420px 240px, rgba(0, 188, 212, 0.25), transparent 60%),
+    radial-gradient(1px 1px at 540px 80px, rgba(255, 255, 255, 0.4), transparent 60%);
+  background-size: 240px 240px;
+  opacity: 0.45;
   pointer-events: none;
-  animation: slow-rotate 60s linear infinite;
-  z-index: -4;
+  z-index: -1;
 }
 
-@keyframes slow-rotate {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+main {
+  width: min(1120px, 92vw);
+  margin: 3rem auto;
+  display: grid;
+  gap: 1.75rem;
+}
+
+header,
+footer {
+  width: min(1120px, 92vw);
+  margin: 2.5rem auto 0;
+  padding: 1.75rem 2.5rem;
+  background: linear-gradient(145deg, rgba(26, 32, 44, 0.92), rgba(45, 55, 72, 0.85));
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-base);
+  box-shadow: var(--panel-shadow);
+  backdrop-filter: blur(12px);
+}
+
+footer {
+  margin-top: auto;
+  margin-bottom: 2.5rem;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text);
+  margin: 0 0 1rem;
+}
+
+h1 {
+  font-size: 2.25rem;
+}
+
+h2 {
+  font-size: 1.75rem;
+}
+
+h3 {
+  font-size: 1.4rem;
+}
+
+p {
+  margin: 0 0 1rem;
+  color: var(--color-muted);
+}
+
+strong,
+b {
+  color: var(--color-text);
 }
 
 a {
@@ -130,568 +124,262 @@ a {
 
 a:hover,
 a:focus-visible {
-  color: var(--color-star);
-  text-shadow: 0 0 4px rgba(0, 206, 209, 0.7);
-}
-
-a:focus-visible,
-button:focus-visible {
-  outline: 2px solid rgba(0, 206, 209, 0.7);
-  outline-offset: 4px;
-  box-shadow: 0 0 12px rgba(0, 206, 209, 0.45);
-}
-
-header,
-footer {
-  position: relative;
-  margin: 2rem auto 1rem;
-  width: min(1100px, 95vw);
-  padding: 1.5rem 2rem;
-  background: linear-gradient(135deg, rgba(9, 10, 15, 0.9), rgba(27, 39, 53, 0.75));
-  border: var(--border-glow);
-  border-radius: var(--radius-panel);
-  box-shadow: var(--shadow-neon);
-  backdrop-filter: blur(10px);
-}
-
-header {
-  display: grid;
-  gap: 1.2rem;
-  align-items: center;
-  justify-items: start;
-}
-
-header::before {
-  content: "Command Center";
-  position: absolute;
-  top: -0.9rem;
-  left: 1.5rem;
-  font-size: 0.75rem;
-  letter-spacing: 0.35em;
-  text-transform: uppercase;
-  color: rgba(0, 206, 209, 0.7);
-  background: rgba(9, 10, 15, 0.85);
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  box-shadow: var(--shadow-neon);
-}
-
-header h1 {
-  margin: 0;
-  font-size: clamp(2.25rem, 3vw + 1rem, 3.4rem);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  text-shadow: 0 0 6px rgba(248, 251, 255, 0.4), 0 0 12px rgba(0, 206, 209, 0.3);
-}
-
-header p {
-  margin: 0;
-  font-size: 1rem;
-  letter-spacing: 0.05em;
-  color: rgba(248, 251, 255, 0.8);
+  color: var(--color-text);
+  text-shadow: 0 0 6px rgba(0, 188, 212, 0.55);
 }
 
 nav {
-  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
 }
 
 nav ul {
   list-style: none;
+  display: flex;
+  gap: 1.25rem;
   margin: 0;
   padding: 0;
-  display: grid;
-  gap: 0.75rem;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-}
-
-nav li {
-  position: relative;
-  padding: 0.75rem 1rem;
-  border-radius: 12px;
-  background: rgba(9, 10, 15, 0.6);
-  border: 1px solid rgba(0, 206, 209, 0.2);
-  box-shadow: inset 0 0 12px rgba(0, 206, 209, 0.08);
-  overflow: hidden;
-  transition: transform var(--transition-slow), box-shadow var(--transition-base);
-}
-
-nav li::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, rgba(0, 206, 209, 0.05), rgba(147, 112, 219, 0.1));
-  opacity: 0;
-  transition: opacity var(--transition-base);
 }
 
 nav a {
-  position: relative;
-  z-index: 1;
   display: inline-flex;
   align-items: center;
-  gap: 0.45rem;
-  justify-content: center;
-  width: 100%;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-nav li:hover,
-nav li:focus-within {
-  transform: translateY(-4px);
-  box-shadow: 0 6px 18px rgba(0, 206, 209, 0.22), inset 0 0 18px rgba(0, 206, 209, 0.18);
-}
-
-nav li:hover::after,
-nav li:focus-within::after {
-  opacity: 1;
-}
-
-nav a[aria-current="page"] {
-  color: var(--color-star);
-  text-shadow: 0 0 6px rgba(0, 206, 209, 0.5);
-}
-
-main {
-  width: min(1100px, 95vw);
-  margin: 1rem auto 2rem;
-  display: grid;
-  gap: 1.75rem;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  perspective: 1200px;
-}
-
-main > section,
-main > article {
-  position: relative;
-  padding: 1.75rem;
-  border-radius: var(--radius-panel);
-  background: var(--color-panel);
-  border: var(--border-glow);
-  box-shadow: var(--shadow-neon);
-  backdrop-filter: blur(12px) saturate(140%);
-  transform-style: preserve-3d;
-  transition: transform var(--transition-slow), box-shadow var(--transition-base), border-color var(--transition-base);
-}
-
-main > section::before,
-main > article::before {
-  content: "";
-  position: absolute;
-  top: 1rem;
-  left: 1.5rem;
-  right: 1.5rem;
-  height: 1px;
-  background: linear-gradient(90deg, rgba(0, 206, 209, 0.35), rgba(147, 112, 219, 0.25));
-  opacity: 0.6;
-}
-
-main > section::after,
-main > article::after {
-  content: "";
-  position: absolute;
-  inset: 10% 6%;
-  border: 1px dashed rgba(0, 206, 209, 0.25);
-  border-radius: calc(var(--radius-panel) - 8px);
-  opacity: 0.4;
-  pointer-events: none;
-}
-
-main > section:hover,
-main > section:focus-within,
-main > article:hover,
-main > article:focus-within {
-  transform: translateY(-6px) rotateX(3deg);
-  box-shadow: 0 18px 30px rgba(0, 0, 0, 0.35), 0 0 20px rgba(0, 206, 209, 0.4);
-  border-color: rgba(0, 206, 209, 0.65);
-}
-
-h2,
-h3 {
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--color-star);
-  margin-top: 0;
-  text-shadow: 0 0 10px rgba(147, 112, 219, 0.3);
-}
-
-p,
-ul,
-ol {
-  color: rgba(248, 251, 255, 0.85);
-  margin-top: 0.75rem;
-}
-
-ul,
-ol {
-  padding-left: 1.2rem;
-}
-
-li::marker {
-  color: rgba(0, 206, 209, 0.8);
-}
-
-article {
-  background: var(--color-panel-strong);
-}
-
-aside {
-  background: rgba(15, 26, 40, 0.8);
-  border: 1px solid rgba(0, 206, 209, 0.35);
-  border-radius: var(--radius-panel);
-  box-shadow: var(--shadow-neon);
-  padding: 1.5rem;
-  backdrop-filter: blur(16px) saturate(160%);
-}
-
-figure {
-  margin: 1.5rem 0;
-  padding: 1.25rem;
-  background: rgba(15, 23, 34, 0.75);
-  border: 1px solid rgba(0, 206, 209, 0.3);
-  border-radius: calc(var(--radius-panel) - 6px);
-  box-shadow: var(--shadow-neon);
-  text-align: center;
-}
-
-img {
-  max-width: 100%;
-  border-radius: 12px;
-  box-shadow: 0 0 18px rgba(0, 206, 209, 0.25);
-}
-
-figcaption {
-  margin-top: 0.75rem;
-  font-size: 0.9rem;
-  letter-spacing: 0.05em;
-  color: rgba(248, 251, 255, 0.7);
-}
-
-article h2::after {
-  content: "";
-  display: block;
-  width: 60px;
-  height: 3px;
-  margin-top: 0.5rem;
-  background: linear-gradient(90deg, rgba(0, 206, 209, 0.7), rgba(147, 112, 219, 0.5));
-  box-shadow: var(--shadow-star);
-}
-
-main > section:nth-of-type(odd),
-main > article:nth-of-type(odd) {
-  animation: float 18s ease-in-out infinite;
-}
-
-main > section:nth-of-type(even),
-main > article:nth-of-type(even) {
-  animation: float 22s ease-in-out infinite reverse;
-}
-
-@keyframes float {
-  0%,
-  100% {
-    transform: translateY(-4px) rotateX(1deg);
-  }
-  50% {
-    transform: translateY(4px) rotateX(-1deg);
-  }
-}
-
-button,
-input[type="button"],
-input[type="submit"] {
-  font-family: var(--font-base);
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  border: 1px solid rgba(0, 206, 209, 0.5);
-  color: var(--color-star);
-  background: linear-gradient(120deg, rgba(0, 206, 209, 0.35), rgba(147, 112, 219, 0.25));
-  padding: 0.75rem 1.5rem;
+  padding: 0.65rem 1rem;
   border-radius: 999px;
-  cursor: pointer;
-  position: relative;
-  overflow: hidden;
-  box-shadow: var(--shadow-neon);
+  border: 1px solid transparent;
+  background: rgba(0, 188, 212, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(0, 188, 212, 0.1);
   transition: transform var(--transition-base), box-shadow var(--transition-base), border-color var(--transition-base);
 }
 
-button::after,
-input[type="button"]::after,
-input[type="submit"]::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 50% 0%, rgba(248, 251, 255, 0.55), transparent 70%);
-  opacity: 0;
-  transition: opacity var(--transition-base);
+nav a:hover,
+nav a:focus-visible {
+  border-color: var(--color-accent);
+  box-shadow: inset 0 0 0 1px var(--color-accent), 0 0 10px rgba(0, 188, 212, 0.35);
+  transform: translateY(-2px);
 }
 
-button:hover,
-input[type="button"]:hover,
-input[type="submit"]:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 0 18px rgba(0, 206, 209, 0.6);
-  border-color: rgba(0, 206, 209, 0.75);
-}
-
-button:hover::after,
-input[type="button"]:hover::after,
-input[type="submit"]:hover::after {
-  opacity: 1;
-}
-
-button:active,
-input[type="button"]:active,
-input[type="submit"]:active {
-  transform: translateY(1px) scale(0.98);
-}
-
-.skip-link,
-body > a[href^="#"] {
-  position: absolute;
-  left: -999px;
-  top: auto;
-  width: 1px;
-  height: 1px;
+.panel {
+  background: linear-gradient(165deg, rgba(26, 32, 44, 0.9), rgba(45, 55, 72, 0.85));
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-base);
+  box-shadow: var(--panel-shadow);
+  padding: 1.75rem 2rem;
+  position: relative;
   overflow: hidden;
 }
 
-body > a[href^="#"]:focus {
-  position: fixed;
-  left: 50%;
-  top: 12px;
-  width: auto;
-  height: auto;
-  padding: 0.5rem 1.5rem;
-  transform: translateX(-50%);
-  background: rgba(9, 10, 15, 0.9);
-  border: var(--border-glow);
-  border-radius: 999px;
-  box-shadow: var(--shadow-neon);
-  z-index: 999;
-}
-
-footer {
-  margin-bottom: 3rem;
-  display: grid;
-  gap: 1rem;
-  align-items: center;
-}
-
-footer::before {
-  content: "Docking Log";
+.panel::before {
+  content: "";
   position: absolute;
-  top: -0.9rem;
-  left: 1.5rem;
-  font-size: 0.7rem;
-  letter-spacing: 0.4em;
-  text-transform: uppercase;
-  color: rgba(147, 112, 219, 0.7);
-  background: rgba(9, 10, 15, 0.85);
-  padding: 0.35rem 0.75rem;
+  inset: 1px;
+  border-radius: calc(var(--radius-base) - 1px);
+  border: 1px solid rgba(255, 255, 255, 0.03);
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.04), transparent 45%);
+  pointer-events: none;
+}
+
+.panel > * {
+  position: relative;
+  z-index: 1;
+}
+
+.grid-panels {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.75rem;
+}
+
+button,
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.75rem 1.25rem;
+  font: inherit;
+  color: var(--color-text);
+  background: rgba(0, 188, 212, 0.12);
+  border: 1px solid var(--panel-border);
   border-radius: 999px;
-  box-shadow: var(--shadow-neon);
+  cursor: pointer;
+  transition: background var(--transition-base), box-shadow var(--transition-base), transform var(--transition-base);
 }
 
-footer nav ul {
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+button:hover,
+button:focus-visible,
+.button:hover,
+.button:focus-visible {
+  background: rgba(0, 188, 212, 0.2);
+  box-shadow: 0 0 10px rgba(0, 188, 212, 0.3);
+  transform: translateY(-1px);
 }
 
-footer p {
-  margin: 0;
-  font-size: 0.95rem;
-  letter-spacing: 0.08em;
-  color: rgba(248, 251, 255, 0.75);
+.table-wrap {
+  overflow-x: auto;
+  border-radius: calc(var(--radius-base) - 4px);
 }
 
-main > section[aria-labelledby],
-main > section[id],
-main > article[id] {
-  padding-top: 2.25rem;
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 600px;
+  color: var(--color-muted);
 }
 
-main > section[aria-labelledby]::before,
-main > section[id]::before,
-main > article[id]::before {
-  height: 12px;
-  background:
-    linear-gradient(90deg, rgba(0, 206, 209, 0.5), rgba(147, 112, 219, 0.35)),
-    radial-gradient(circle, var(--color-accent) 0 55%, transparent 60%);
-  background-size: 100% 1px, 12px 12px;
-  background-position: center, right 0.5rem center;
-  background-repeat: no-repeat;
-  border-radius: 0;
-  opacity: 0.85;
+thead {
+  color: var(--color-text);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.85rem;
+}
+
+thead th {
+  padding: 0.75rem;
+  background: rgba(0, 188, 212, 0.12);
+  border-bottom: 1px solid rgba(0, 188, 212, 0.25);
+}
+
+tbody tr {
+  transition: background var(--transition-base), box-shadow var(--transition-base);
+}
+
+tbody tr:nth-child(even) {
+  background: rgba(26, 32, 44, 0.55);
+}
+
+tbody tr:hover {
+  background: rgba(0, 188, 212, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(0, 188, 212, 0.15);
+}
+
+td {
+  padding: 0.75rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+ul,
+ol {
+  margin: 0 0 1.2rem 1.5rem;
+  padding: 0;
 }
 
 code,
 pre {
-  font-family: var(--font-base);
-  background: rgba(9, 10, 15, 0.7);
-  border: 1px solid rgba(0, 206, 209, 0.3);
+  font-family: var(--font-mono);
+  background: rgba(0, 188, 212, 0.08);
+  border: 1px solid rgba(0, 188, 212, 0.2);
   border-radius: 8px;
-  padding: 0.35rem 0.6rem;
-  box-shadow: inset 0 0 12px rgba(0, 206, 209, 0.18);
+  padding: 0.35rem 0.5rem;
+  color: var(--color-text);
 }
 
 blockquote {
-  position: relative;
-  margin: 1.5rem 0;
-  padding: 1.2rem 1.5rem 1.2rem 2rem;
-  background: rgba(18, 28, 44, 0.82);
-  border-left: 3px solid rgba(0, 206, 209, 0.6);
-  box-shadow: var(--shadow-neon);
-}
-
-blockquote::before {
-  content: "\201C";
-  position: absolute;
-  top: -0.6rem;
-  left: 0.6rem;
-  font-size: 3rem;
-  color: rgba(0, 206, 209, 0.35);
-}
-
-.table-like,
-table {
-  width: 100%;
-  border-collapse: collapse;
-  background: rgba(18, 28, 44, 0.75);
-  border: 1px solid rgba(0, 206, 209, 0.2);
-  border-radius: 12px;
-  overflow: hidden;
-  box-shadow: var(--shadow-neon);
-}
-
-table caption {
-  caption-side: top;
-  padding: 1rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-thead {
-  background: rgba(0, 206, 209, 0.2);
-}
-
-td,
-th {
-  padding: 0.9rem 1rem;
-  text-align: left;
-  border-bottom: 1px solid rgba(0, 206, 209, 0.15);
-}
-
-tr:hover {
-  background: rgba(147, 112, 219, 0.12);
+  margin: 0 0 1.5rem;
+  padding: 1rem 1.25rem;
+  border-left: 3px solid var(--color-accent);
+  background: rgba(26, 32, 44, 0.65);
+  border-radius: calc(var(--radius-base) - 6px);
+  color: var(--color-muted);
 }
 
 form {
   display: grid;
-  gap: 1rem;
-  background: rgba(18, 28, 44, 0.8);
-  border: 1px solid rgba(0, 206, 209, 0.35);
-  border-radius: var(--radius-panel);
-  padding: 1.5rem;
-  box-shadow: var(--shadow-neon);
+  gap: 1.25rem;
 }
 
 label {
-  display: inline-block;
-  font-weight: 600;
-  letter-spacing: 0.08em;
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
-  margin-bottom: 0.35rem;
+  color: var(--color-text);
 }
 
 input,
 textarea,
 select {
-  font-family: var(--font-base);
-  background: rgba(9, 10, 15, 0.7);
-  border: 1px solid rgba(0, 206, 209, 0.35);
-  border-radius: 10px;
-  color: var(--color-star);
+  width: 100%;
   padding: 0.75rem 1rem;
-  box-shadow: inset 0 0 12px rgba(147, 112, 219, 0.18);
+  font: inherit;
+  color: var(--color-text);
+  background: rgba(26, 32, 44, 0.75);
+  border: 1px solid rgba(0, 188, 212, 0.25);
+  border-radius: 10px;
   transition: border-color var(--transition-base), box-shadow var(--transition-base);
 }
 
-input:focus,
-textarea:focus,
-select:focus {
-  border-color: rgba(0, 206, 209, 0.8);
-  box-shadow: 0 0 12px rgba(0, 206, 209, 0.5);
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
   outline: none;
-}
-
-[data-system-control],
-button.theme-toggle {
-  border-radius: 12px;
-  padding: 0.65rem 1.25rem;
-  background: linear-gradient(145deg, rgba(0, 206, 209, 0.22), rgba(147, 112, 219, 0.22));
-  border: 1px solid rgba(0, 206, 209, 0.4);
-  box-shadow: 0 0 12px rgba(0, 206, 209, 0.35), inset 0 0 10px rgba(147, 112, 219, 0.25);
-}
-
-[data-system-control]:hover,
-button.theme-toggle:hover {
-  box-shadow: 0 0 18px rgba(0, 206, 209, 0.55), inset 0 0 16px rgba(147, 112, 219, 0.35);
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 2px rgba(0, 188, 212, 0.25);
 }
 
 hr {
-  border: none;
-  border-top: 1px solid rgba(0, 206, 209, 0.3);
+  border: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(0, 188, 212, 0.5), transparent);
   margin: 2rem 0;
-  box-shadow: 0 0 10px rgba(0, 206, 209, 0.3);
 }
 
-@media (min-width: 900px) {
-  header {
-    grid-template-columns: 1fr minmax(320px, 1fr);
-    align-items: center;
+small {
+  color: rgba(245, 247, 255, 0.5);
+  letter-spacing: 0.04em;
+}
+
+@media (max-width: 1024px) {
+  main {
+    width: min(960px, 94vw);
   }
 
-  header nav {
-    justify-self: end;
-    width: 100%;
+  header,
+  footer {
+    width: min(960px, 94vw);
+    padding: 1.5rem 2rem;
   }
 
-  header nav ul {
-    grid-template-columns: none;
-    grid-auto-flow: column;
-    grid-auto-columns: minmax(120px, 1fr);
+  .grid-panels {
+    grid-template-columns: 1fr;
+  }
+
+  nav {
+    flex-wrap: wrap;
+    justify-content: center;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width: 768px) {
+  html {
+    font-size: 16px;
+  }
+
+  body {
+    line-height: 1.6;
+  }
+
+  header,
+  footer,
+  main {
+    width: 92vw;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
   header,
   footer {
     padding: 1.25rem 1.5rem;
   }
 
   nav ul {
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
   }
 
-  main {
-    grid-template-columns: 1fr;
-  }
-
-  main > section,
-  main > article {
-    padding: 1.5rem;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.001ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.001ms !important;
-    scroll-behavior: auto !important;
+  nav a {
+    justify-content: center;
   }
 }


### PR DESCRIPTION
## Summary
- rebuild the space theme stylesheet with desktop-first sci-fi styling and monospace typography
- introduce panel, navigation, and table treatments with subtle cyan glows and organized layouts
- add responsive adjustments for medium and small screens while keeping a gradient starfield backdrop

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfe6ac0ed0832888d3404c5959387d